### PR TITLE
set window size based on monitor res

### DIFF
--- a/command_line/sim_view.py
+++ b/command_line/sim_view.py
@@ -1186,7 +1186,9 @@ if __name__ == '__main__':
         
         root.title("SimView")
         
-        root.geometry('1920x1140')
+        wd = int(root.winfo_screenwidth()*.8)
+        ht = int(root.winfo_screenheight()*.8)
+        root.geometry('%dx%d' % (wd, ht))
         
         frame = SimView(root, params_num, params_cat, params_info, params_hyper, pdbfile)
         


### PR DESCRIPTION
This sets the sim_view window to take up a fraction of the available monitor space (80% of both width and height)

Otherwise, for someone working at a lower resolution than what was hard-coded, the sim_view window always expands to the full screen, which I think should be a non-default behavior. 